### PR TITLE
Default to showing all PHP errors while providing ini input

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -30,7 +30,7 @@ on:
         description: PHP ini values
         type: string
         required: false
-        default: display_errors=E_ALL
+        default: error_reporting=E_ALL
 
 env:
   COMPOSER_ROOT_VERSION: dev-main

--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -8,13 +8,13 @@ on:
         type: boolean
         default: true
         required: false
-        
+
       backend_directory:
         description: The directory of the project where backend code is located. This should contain a `composer.json` file, and is generally the root directory of the repo.
         type: string
         required: false
         default: '.'
-        
+
       php_versions:
         description: Versions of PHP to test with. Should be array of strings encoded as JSON array
         type: string
@@ -25,7 +25,13 @@ on:
         type: string
         required: false
         default: '["mysql:5.7", "mariadb"]'
-        
+
+      php_ini_values:
+        description: PHP ini values
+        type: string
+        required: false
+        default: display_errors=E_ALL
+
 env:
   COMPOSER_ROOT_VERSION: dev-main
   FLARUM_TEST_TMP_DIR_LOCAL: tests/integration/tmp
@@ -76,6 +82,7 @@ jobs:
           coverage: xdebug
           extensions: curl, dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, zip
           tools: phpunit, composer:v2
+          ini-values: ${{ inputs.php_ini_values }}
 
       # The authentication alter is necessary because newer mysql versions use the `caching_sha2_password` driver,
       # which isn't supported prior to PHP7.4


### PR DESCRIPTION
* For the test suite to catch warnings and deprecations, we need to explicitly set `display_errors=E_ALL`.
* Adds an input to change in values for more developer flexibility.