### PR TITLE
Start testing with PHP 8.2

### DIFF
--- a/.github/workflows/REUSABLE_backend.yml
+++ b/.github/workflows/REUSABLE_backend.yml
@@ -19,7 +19,7 @@ on:
         description: Versions of PHP to test with. Should be array of strings encoded as JSON array
         type: string
         required: false
-        default: '["7.4", "8.0", "8.1"]'
+        default: '["7.4", "8.0", "8.1", "8.2"]'
       db_versions:
         description: Versions of databases to test with. Should be array of strings encoded as JSON array
         type: string


### PR DESCRIPTION
Despite PHP 8.2 still being in alpha, it's still useful to run tests against it as means of getting a rough idea as to what changes will be needed once it becomes production ready.