### PR TITLE
docs: increase logo resolution

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-<p align="center"><a href="https://flarum.org" target="_blank"><img src="https://flarum.org/assets/img/logo.png" width="400"></a></p>
+<p align="center"><a href="https://flarum.org" target="_blank"><img src="https://user-images.githubusercontent.com/19341857/180593471-c76f6952-6840-4c18-8cec-1cc003f5af05.png" width="400"></a></p>
 
 ## About Flarum, forums made simple
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,5 @@
-<p align="center"><a href="https://flarum.org" target="_blank"><img src="https://user-images.githubusercontent.com/19341857/180593471-c76f6952-6840-4c18-8cec-1cc003f5af05.png" width="400"></a></p>
+<p align="center"><a href="https://flarum.org" target="_blank"><img src="https://user-images.githubusercontent.com/19341857/181917693-c9391c43-65f3-4986-a972-97012404f6ed.svg" width="400"></a></p>
+
 
 ## About Flarum, forums made simple
 


### PR DESCRIPTION
Fixes [N/A]

**Changes proposed in this pull request:**
README.md is using the logo with the width of 400px, but the logo is only 298px, so it looks blurry. Here, it's being replaced by a higher resolution version. I downloaded the .svg version of the logo from
https://github.com/flarum/framework/blob/main/framework/core/views/install/logo.svg
and then exported to png with the width of 400px. However, 400px version didn't look as crisp as it could, so I increased it to around 1000px so that it looks perfectly crisp.

**Reviewers should focus on:**
N/A

**Screenshot**
![current](https://user-images.githubusercontent.com/19341857/180593769-5d405d0c-e032-45bb-94d3-94ad3a1cd2a8.png)

This is how it was. The logo was blurry. Here's after change:

![now](https://user-images.githubusercontent.com/19341857/180594239-e5020db5-4f98-40f4-9adc-193847328b97.png)

We're still using width="400" so the overall size didn't change, but it's crisp now.

**Necessity**

- [x] N/A

**Confirmed**

- [x] N/A

**Required changes:**

- [x] N/A